### PR TITLE
v0.0.3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+require('module-alias/register');
 const express_1 = require("express");
 const verdaccio_fleetbase_s3_storage_1 = __importDefault(require("@fleetbase/verdaccio-fleetbase-s3-storage"));
 class ComposerMiddleware {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
             "dependencies": {
                 "@fleetbase/verdaccio-fleetbase-s3-storage": "0.0.1",
                 "@verdaccio/commons-api": "10.2.0",
-                "express": "4.18.1"
+                "express": "4.18.1",
+                "module-alias": "^2.2.3"
             },
             "devDependencies": {
                 "@types/express": "4.17.13",
@@ -4886,6 +4887,11 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/module-alias": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+            "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
         },
         "node_modules/ms": {
             "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/verdaccio-composer-middleware",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Middleware to handle composer dependency request.",
     "keywords": [
         "verdaccio",
@@ -28,20 +28,24 @@
         "node": ">=12"
     },
     "dependencies": {
-        "express": "4.18.1",
         "@fleetbase/verdaccio-fleetbase-s3-storage": "0.0.1",
-        "@verdaccio/commons-api": "10.2.0"
+        "@verdaccio/commons-api": "10.2.0",
+        "express": "4.18.1",
+        "module-alias": "^2.2.3"
     },
     "devDependencies": {
-        "@verdaccio/types": "10.5.2",
-        "@verdaccio/legacy-types": "^1.0.1",
         "@types/express": "4.17.13",
         "@types/jest": "27.5.1",
         "@types/node": "12.12.5",
         "@typescript-eslint/eslint-plugin": "5.26.0",
         "@typescript-eslint/parser": "5.26.0",
+        "@verdaccio/legacy-types": "^1.0.1",
+        "@verdaccio/types": "10.5.2",
         "eslint": "8.21.0",
         "jest": "28.1.3",
         "typescript": "4.7.4"
+    },
+    "_moduleAliases": {
+        "@fleetbase/verdaccio-fleetbase-s3-storage": "/verdaccio/plugins/verdaccio-fleetbase-s3-storage"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+require('module-alias/register');
+
 import { Logger, IPluginMiddleware, IBasicAuth, IStorageManager, PluginOptions, Config } from '@verdaccio/types';
 import { Router, Request, Response, NextFunction, Application } from 'express';
 import { CustomConfig } from './types/index';


### PR DESCRIPTION
- must use `module-alias` to use fleetbase-s3 plugin as a runtime dependency when running as verdaccio plugin